### PR TITLE
Move to uv + add google-crc32 build from nix

### DIFF
--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -84,7 +84,7 @@
       "VITE_TIME_PER_PAGE": "50"
     },
     "hook": {
-      "on-activate": "  # If we export this here, it can be used later in 'profiles.common/bash'\n  export PYTHON_DIR=\"$FLOX_ENV_CACHE/python\"\n\n  test -d \"${PYTHON_DIR}\" \\\n    || uv venv \"${PYTHON_DIR}\" --allow-existing\n  source \"$PYTHON_DIR/bin/activate\"\n  \n  uv pip install -r backend/requirements.txt\n\n  yarn --cwd frontend install\n"
+      "on-activate": "  # If we export this here, it can be used later in 'profiles.common/bash'\n  export PYTHON_DIR=\"$FLOX_ENV_CACHE/python\"\n\n  test -d \"${PYTHON_DIR}\" \\\n    || uv venv \"${PYTHON_DIR}\" --allow-existing\n  source \"$PYTHON_DIR/bin/activate\"\n  \n  uv pip install -r backend/requirements.txt\n\n  yarn --cwd frontend install\n\n  echo \"\n  you can check the status of the llama3 model with:\n    flox services logs --follow models\n  or:\n    ollama list\n  \"\n"
     },
     "profile": {
       "bash": "source \"$PYTHON_DIR/bin/activate\"\n",
@@ -120,7 +120,7 @@
         "systems": null
       },
       "models": {
-        "command": "# wait for ollama to be ready\nuntil ollama list; do\n  sleep 0.1\ndone\n\nollama pull llama3:latest\n",
+        "command": "# wait for ollama to be ready\nuntil ollama list; do\n  sleep 0.1\ndone\n\nollama list | grep -q \"^llama3\" || ollama pull llama3:latest\n",
         "vars": null,
         "is-daemon": null,
         "shutdown": null,

--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -84,7 +84,7 @@
       "VITE_TIME_PER_PAGE": "50"
     },
     "hook": {
-      "on-activate": "# If we export this here, it can be used later in 'profiles.common'\nexport PYTHON_DIR=\"$FLOX_ENV_CACHE/python\"\n\n  test -d \"${PYTHON_DIR}\" \\\n    || uv venv \"${PYTHON_DIR}\" --allow-existing\n  source \"$PYTHON_DIR/bin/activate\"\n  \n  uv pip install -r backend/requirements.txt\n\n  yarn --cwd frontend install\n"
+      "on-activate": "  # If we export this here, it can be used later in 'profiles.common/bash'\n  export PYTHON_DIR=\"$FLOX_ENV_CACHE/python\"\n\n  test -d \"${PYTHON_DIR}\" \\\n    || uv venv \"${PYTHON_DIR}\" --allow-existing\n  source \"$PYTHON_DIR/bin/activate\"\n  \n  uv pip install -r backend/requirements.txt\n\n  yarn --cwd frontend install\n\n  ollama list | grep \"^llama3\" || ollama pull llama3\n"
     },
     "profile": {
       "bash": "source \"$PYTHON_DIR/bin/activate\"\n",

--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -16,8 +16,8 @@
           "aarch64-linux"
         ]
       },
-      "gum": {
-        "pkg-path": "gum"
+      "google-crc32c": {
+        "pkg-path": "python311Packages.google-crc32c"
       },
       "neo4j": {
         "pkg-path": "neo4j"
@@ -34,11 +34,15 @@
       "poppler_utils": {
         "pkg-path": "poppler_utils"
       },
-      "python3": {
-        "pkg-path": "python3"
+      "python": {
+        "pkg-path": "python311",
+        "priority": 0
       },
       "tesseract": {
         "pkg-path": "tesseract"
+      },
+      "uv": {
+        "pkg-path": "uv"
       },
       "yarn": {
         "pkg-path": "yarn"
@@ -64,6 +68,8 @@
       "NUMBER_OF_CHUNKS_TO_COMBINE": "6",
       "OPENAI_API_KEY": "",
       "UPDATE_GRAPH_CHUNKS_PROCESSED": "20",
+      "UV_PYTHON_DOWNLOADS": "never",
+      "UV_PYTHON_PREFERENCE": "only-system",
       "VITE_BACKEND_API_URL": "http://localhost:8000",
       "VITE_BATCH_SIZE": "2",
       "VITE_BLOOM_URL": "https://workspace-preview.neo4j.io/workspace/explore?connectURL={CONNECT_URL}&search=Show+me+a+graph&featureGenAISuggestions=true&featureGenAISuggestionsInternal=true",
@@ -78,10 +84,13 @@
       "VITE_TIME_PER_PAGE": "50"
     },
     "hook": {
-      "on-activate": "# If we export this here, it can be used later in 'profiles.common'\nexport PYTHON_DIR=\"$FLOX_ENV_CACHE/python\"\n\nif [ ! -d \"$PYTHON_DIR\" ]; then\n  gum spin -s globe --title \"Creating venv in $PYTHON_DIR...\" -- python -m venv \"$PYTHON_DIR\"\nfi\n\n(\n  source \"$PYTHON_DIR/bin/activate\"\n  gum spin -s monkey --title \"Installing/updating requirements.txt ...\" -- pip install -r backend/requirements.txt\n)\n\n(\n  cd frontend\n  gum spin -s monkey --title \"Installing/updating JS dependencies ...\" -- yarn install\n)\n"
+      "on-activate": "# If we export this here, it can be used later in 'profiles.common'\nexport PYTHON_DIR=\"$FLOX_ENV_CACHE/python\"\n\n  test -d \"${PYTHON_DIR}\" \\\n    || uv venv \"${PYTHON_DIR}\" --allow-existing\n  source \"$PYTHON_DIR/bin/activate\"\n  \n  uv pip install -r backend/requirements.txt\n\n  yarn --cwd frontend install\n"
     },
     "profile": {
-      "common": "  # Activate the Python venv\n  source \"$PYTHON_DIR/bin/activate\"\n"
+      "bash": "source \"$PYTHON_DIR/bin/activate\"\n",
+      "zsh": "source \"$PYTHON_DIR/bin/activate\"\n",
+      "fish": "source \"$PYTHON_DIR/bin/activate.fish\"\n",
+      "tcsh": "source \"$PYTHON_DIR/bin/activate.csh\"\n"
     },
     "options": {
       "systems": [
@@ -123,28 +132,28 @@
     {
       "attr_path": "cmake",
       "broken": false,
-      "derivation": "/nix/store/b70cbvhx8r9hmg10kzawr6myb4j879zs-cmake-3.30.4.drv",
+      "derivation": "/nix/store/pn4kzpll0lvr1pd7jh1r45hvnjayalzd-cmake-3.30.5.drv",
       "description": "Cross-platform, open-source build system generator",
       "install_id": "cmake",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
-      "name": "cmake-3.30.4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "name": "cmake-3.30.5",
       "pname": "cmake",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "3.30.4",
+      "version": "3.30.5",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/wjja52fahksjwnikmy09n5y2pa7dymma-cmake-3.30.4"
+        "out": "/nix/store/aw70f6alsbf7cgn5qwqbpgd1w208i3v9-cmake-3.30.5"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -153,29 +162,29 @@
     {
       "attr_path": "cmake",
       "broken": false,
-      "derivation": "/nix/store/v8n6nhdq57jcmfnm277d0fla5wsk3a27-cmake-3.30.4.drv",
+      "derivation": "/nix/store/p24ff2w0l1ycsk4bdj6gvij9flbh6v9r-cmake-3.30.5.drv",
       "description": "Cross-platform, open-source build system generator",
       "install_id": "cmake",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
-      "name": "cmake-3.30.4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "name": "cmake-3.30.5",
       "pname": "cmake",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "3.30.4",
+      "version": "3.30.5",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "debug": "/nix/store/8s1jn7aj6k5r0dzga4na6mf2hmbhd62a-cmake-3.30.4-debug",
-        "out": "/nix/store/i8hfbcxgsp8aj8vhsscxyjsglilwd5i3-cmake-3.30.4"
+        "debug": "/nix/store/nlqn5rq3yx0qm0ibfn087bjxdb3y5vkn-cmake-3.30.5-debug",
+        "out": "/nix/store/71swssqfb007860ik9r7xgfb1i39dz7v-cmake-3.30.5"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -184,28 +193,28 @@
     {
       "attr_path": "cmake",
       "broken": false,
-      "derivation": "/nix/store/10xbk4bmd2f6fpmn6diby3p023hjgaf0-cmake-3.30.4.drv",
+      "derivation": "/nix/store/hzd8dl6c8w8zb698q6p9p1bfgh7wxsck-cmake-3.30.5.drv",
       "description": "Cross-platform, open-source build system generator",
       "install_id": "cmake",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
-      "name": "cmake-3.30.4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "name": "cmake-3.30.5",
       "pname": "cmake",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "3.30.4",
+      "version": "3.30.5",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/y0gmpiv78vyxb0bfqm8y58hqazjkpm7l-cmake-3.30.4"
+        "out": "/nix/store/6paqqjczjfv8z2i6qr7gdfq21n0rbglr-cmake-3.30.5"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -214,29 +223,29 @@
     {
       "attr_path": "cmake",
       "broken": false,
-      "derivation": "/nix/store/v5mzfidz2cwydxw640imkb10q9nf2gly-cmake-3.30.4.drv",
+      "derivation": "/nix/store/kjjiyylzynx598rr76l8cld6wdn1nv50-cmake-3.30.5.drv",
       "description": "Cross-platform, open-source build system generator",
       "install_id": "cmake",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
-      "name": "cmake-3.30.4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "name": "cmake-3.30.5",
       "pname": "cmake",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "3.30.4",
+      "version": "3.30.5",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "debug": "/nix/store/wqa3jwxi67szp5q7s89x58a31791qh7s-cmake-3.30.4-debug",
-        "out": "/nix/store/irwcgpm8csj7br49jih6kdpqkaqya3vf-cmake-3.30.4"
+        "debug": "/nix/store/f6wqljm9lncszmj652011lfjr5bpv6q1-cmake-3.30.5-debug",
+        "out": "/nix/store/4kb60dy0dg80ww8gh2av4by4vwn8l48k-cmake-3.30.5"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -245,17 +254,17 @@
     {
       "attr_path": "gcc-unwrapped",
       "broken": false,
-      "derivation": "/nix/store/zzh3d4wf8w67qqj32r3b7j5w1fs6v000-gcc-13.3.0.drv",
+      "derivation": "/nix/store/f8n159dq09497f880ydyzbdis7k158sl-gcc-13.3.0.drv",
       "description": "GNU Compiler Collection, version 13.3.0",
       "install_id": "gcc-unwrapped",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "gcc-13.3.0",
       "pname": "gcc-unwrapped",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -267,10 +276,10 @@
         "man"
       ],
       "outputs": {
-        "info": "/nix/store/6fcj0zv706pd8n7mnlx5978fgd8ix4w5-gcc-13.3.0-info",
-        "lib": "/nix/store/l2ddckkxxhld9zbk1s7ihyr93w1ha3k6-gcc-13.3.0-lib",
-        "man": "/nix/store/zay1dqk3yadbmc9fb4qdm7sj907sidhp-gcc-13.3.0-man",
-        "out": "/nix/store/2h4d35c6ips03q1dk06r5dqi5r5xk7km-gcc-13.3.0"
+        "info": "/nix/store/blrksyc2pyqb0fygx1scsi6j4bd7xr3i-gcc-13.3.0-info",
+        "lib": "/nix/store/6k3fs4snnj9q0ynz9l83vd7laxfz8wfh-gcc-13.3.0-lib",
+        "man": "/nix/store/838z4n3ij96k0b08sw052ackalwblscq-gcc-13.3.0-man",
+        "out": "/nix/store/2sfhg1xf6bd4lnmzjx27x78kavwcg3sf-gcc-13.3.0"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -279,17 +288,17 @@
     {
       "attr_path": "gcc-unwrapped",
       "broken": false,
-      "derivation": "/nix/store/x7zks9054krlhcm6ddxaa42jwmmyhmv9-gcc-13.3.0.drv",
+      "derivation": "/nix/store/5pjjnvindmwc0l4fxg3vxc07d95pwxgp-gcc-13.3.0.drv",
       "description": "GNU Compiler Collection, version 13.3.0",
       "install_id": "gcc-unwrapped",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "gcc-13.3.0",
       "pname": "gcc-unwrapped",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -301,12 +310,12 @@
         "man"
       ],
       "outputs": {
-        "checksum": "/nix/store/53z59d7pyzv3nri22mhlg0ng39zbrdcy-gcc-13.3.0-checksum",
-        "info": "/nix/store/p181ly5hkdamfcf8gdc055r481kcvkmx-gcc-13.3.0-info",
-        "lib": "/nix/store/kgw66wx3ybci6p4xnrr8x7c8xb4n82wl-gcc-13.3.0-lib",
-        "libgcc": "/nix/store/ybxxxclh0nnwni5alzz9yj73k84bnj8a-gcc-13.3.0-libgcc",
-        "man": "/nix/store/kw3w08012c0i35kr331pp9r9g68yhcl9-gcc-13.3.0-man",
-        "out": "/nix/store/rsqi0h743vzhnmsby3rvxdqbcfbq3p6q-gcc-13.3.0"
+        "checksum": "/nix/store/643gzkarm2bcj75qnyp37xbkhj18n6fc-gcc-13.3.0-checksum",
+        "info": "/nix/store/93bwqif5h2c04afiib2alv9xnmxhkiyd-gcc-13.3.0-info",
+        "lib": "/nix/store/7nrbhacy4l27xq12q3pji7nv251w807a-gcc-13.3.0-lib",
+        "libgcc": "/nix/store/hbx662db56zlcxg4y5lgmrra16k30ws6-gcc-13.3.0-libgcc",
+        "man": "/nix/store/5vz9v54197mbqvj1qjnmsvjiqv2yma49-gcc-13.3.0-man",
+        "out": "/nix/store/pxb3zpbg0qdccadh884fag33va0xb4ds-gcc-13.3.0"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -315,17 +324,17 @@
     {
       "attr_path": "gcc-unwrapped",
       "broken": false,
-      "derivation": "/nix/store/i5i8dg15hq6c1jwqmq2hm5pfxk6wihz2-gcc-13.3.0.drv",
+      "derivation": "/nix/store/pp9rmxlwir5j8f8xasnr8y0vz5r1flh0-gcc-13.3.0.drv",
       "description": "GNU Compiler Collection, version 13.3.0",
       "install_id": "gcc-unwrapped",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "gcc-13.3.0",
       "pname": "gcc-unwrapped",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -337,10 +346,10 @@
         "man"
       ],
       "outputs": {
-        "info": "/nix/store/qbff1j84p8wwjwdi7jrsmgy8685zjjj3-gcc-13.3.0-info",
-        "lib": "/nix/store/1y6761i9c0z64aj5md76l65xdcphypfy-gcc-13.3.0-lib",
-        "man": "/nix/store/4a9xbmwnz0wcf2vs0wapyn1ahjbk5p05-gcc-13.3.0-man",
-        "out": "/nix/store/2d7yvv5nn4361mphq0l107082dckgiwi-gcc-13.3.0"
+        "info": "/nix/store/38mfbrb0ckmhsjlxqns54radgwhy1ifa-gcc-13.3.0-info",
+        "lib": "/nix/store/92i7bygvwhjw9b9277l8y5kxkh7cd8q9-gcc-13.3.0-lib",
+        "man": "/nix/store/xdpgzcjdw8x615fgblsan6l5qxyphnv4-gcc-13.3.0-man",
+        "out": "/nix/store/4dx3p04kq8q2wirqq7dxjxxby4mf70nk-gcc-13.3.0"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -349,17 +358,17 @@
     {
       "attr_path": "gcc-unwrapped",
       "broken": false,
-      "derivation": "/nix/store/gnwn80wknvqg8cjyc094gmv7d8g3za1z-gcc-13.3.0.drv",
+      "derivation": "/nix/store/d501c7jfvisxah7bpaw3a7lx0z1l26qn-gcc-13.3.0.drv",
       "description": "GNU Compiler Collection, version 13.3.0",
       "install_id": "gcc-unwrapped",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "gcc-13.3.0",
       "pname": "gcc-unwrapped",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -371,12 +380,12 @@
         "man"
       ],
       "outputs": {
-        "checksum": "/nix/store/q1dz82hi7hjzhy8815d3fdddrk60kqnn-gcc-13.3.0-checksum",
-        "info": "/nix/store/6zk22yslw938zxhrffyj4rs7wi1vmv6r-gcc-13.3.0-info",
-        "lib": "/nix/store/s94fwp43xhzkvw8l8nqslskib99yifzi-gcc-13.3.0-lib",
-        "libgcc": "/nix/store/c91k93z9yr1cpia2pf5dr226imglrkg5-gcc-13.3.0-libgcc",
-        "man": "/nix/store/zls8qr49k7bkdfb9ncqz9w38q5m8zkld-gcc-13.3.0-man",
-        "out": "/nix/store/v7dbfh5n7az2lcap0z1cv4jq0bikya8p-gcc-13.3.0"
+        "checksum": "/nix/store/19vpn2rnrzf8l1vbhvrd5qzxmxp6n3pw-gcc-13.3.0-checksum",
+        "info": "/nix/store/h5bp0gwbidib7j5jcgl6nivab523mqj3-gcc-13.3.0-info",
+        "lib": "/nix/store/97f3gw9vpyxvwjv2i673isvg92q65mwn-gcc-13.3.0-lib",
+        "libgcc": "/nix/store/nhdjqagplar2fdrqnrxlab8vg9i36b3d-gcc-13.3.0-libgcc",
+        "man": "/nix/store/8f91g3cshb8mgxdpsphwzwirq50wspjm-gcc-13.3.0-man",
+        "out": "/nix/store/xzfmarrq8x8s4ivpya24rrndqsq2ndiz-gcc-13.3.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -385,17 +394,17 @@
     {
       "attr_path": "glibc",
       "broken": false,
-      "derivation": "/nix/store/cxd5si2wb4qr1p20m79xdp1gdxfjyg7l-glibc-2.40-36.drv",
+      "derivation": "/nix/store/nxxwgq50lc44h9jb92d7wpya8dzdyv4f-glibc-2.40-36.drv",
       "description": "GNU C Library",
       "install_id": "glibc",
       "license": "LGPL-2.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "glibc-2.40-36",
       "pname": "glibc",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -406,12 +415,12 @@
         "bin"
       ],
       "outputs": {
-        "bin": "/nix/store/5571d6dklkwfcp1812dj4lxb0gl3w1yw-glibc-2.40-36-bin",
-        "debug": "/nix/store/4hyvva1qccsqw6w2vy8p9rb659hjm8lh-glibc-2.40-36-debug",
-        "dev": "/nix/store/932dj5qwfzck90mnvqpd1f9hjqznaqdj-glibc-2.40-36-dev",
-        "getent": "/nix/store/az5vszpdy3i53lksl8rbjai7bc88r5zs-glibc-2.40-36-getent",
-        "out": "/nix/store/3bvxjkkmwlymr0fssczhgi39c3aj1l7i-glibc-2.40-36",
-        "static": "/nix/store/dn3xrgx3gcg6y4ijnjrxm8px2d7rh6zk-glibc-2.40-36-static"
+        "bin": "/nix/store/26dy2y29fhissya64ygahwpidpvs3bm3-glibc-2.40-36-bin",
+        "debug": "/nix/store/1qqb6gq3jy59vyiziid7v61ndfnyyhpi-glibc-2.40-36-debug",
+        "dev": "/nix/store/aax0hx68i2ikhpf27hdm6a2a209d4s6p-glibc-2.40-36-dev",
+        "getent": "/nix/store/vl4lc1kqvvdmwsp0dvqlhqk10nhhddpl-glibc-2.40-36-getent",
+        "out": "/nix/store/pacbfvpzqz2mksby36awvbcn051zcji3-glibc-2.40-36",
+        "static": "/nix/store/s11lgr4hm29dr32pfw936fgnbk0w4jhb-glibc-2.40-36-static"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -420,17 +429,17 @@
     {
       "attr_path": "glibc",
       "broken": false,
-      "derivation": "/nix/store/0v2m9id0vhckxrib6h4177py31nlcd4z-glibc-2.40-36.drv",
+      "derivation": "/nix/store/4pdgyc19cpijj1a7lsswyv79c46v5vv4-glibc-2.40-36.drv",
       "description": "GNU C Library",
       "install_id": "glibc",
       "license": "LGPL-2.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "glibc-2.40-36",
       "pname": "glibc",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -441,132 +450,136 @@
         "bin"
       ],
       "outputs": {
-        "bin": "/nix/store/pp0sc4ry232c2f3cfljhp4ncfmbc2dpw-glibc-2.40-36-bin",
-        "debug": "/nix/store/jvinvfjml28l2b56c4wdgb4kgnk0llia-glibc-2.40-36-debug",
-        "dev": "/nix/store/ah9kr35lsmsa8gxngkksj02xir5li1yh-glibc-2.40-36-dev",
-        "getent": "/nix/store/1z4vn6rphd7w1ixgvisxxm6dk6ffmm2g-glibc-2.40-36-getent",
-        "out": "/nix/store/mkg8ismz3szq25r4gzq77xblkkp518r0-glibc-2.40-36",
-        "static": "/nix/store/k91gp7k55284ymy2blxy82msipr3m3mf-glibc-2.40-36-static"
+        "bin": "/nix/store/dy3ff7xr55p69gxs8py1ll67vlim1z3n-glibc-2.40-36-bin",
+        "debug": "/nix/store/l91gbzf4d73p92lviwbjy1yk86dxb47i-glibc-2.40-36-debug",
+        "dev": "/nix/store/afn0xk2xd1dcvfyfq1bawhgbdz7arfp2-glibc-2.40-36-dev",
+        "getent": "/nix/store/8zcnkq8687m2vryzifc9g6k0rn45nfc2-glibc-2.40-36-getent",
+        "out": "/nix/store/w0gi2q79avgm6fr2mikgjl6z781rq0h7-glibc-2.40-36",
+        "static": "/nix/store/zbjpjqdlx48gw2p2107r4kybdhvf3fnk-glibc-2.40-36-static"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
       "priority": 5
     },
     {
-      "attr_path": "gum",
+      "attr_path": "python311Packages.google-crc32c",
       "broken": false,
-      "derivation": "/nix/store/sd2srnb6d2qsj3kamc0wnhpq1y9phpll-gum-0.14.5.drv",
-      "description": "Tasty Bubble Gum for your shell",
-      "install_id": "gum",
-      "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
-      "name": "gum-0.14.5",
-      "pname": "gum",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "derivation": "/nix/store/v7kkhkh1sz489gvglqlvfylsays3r8xr-python3.11-google-crc32c-1.6.0.drv",
+      "description": "Wrapper the google/crc32c hardware-based implementation of the CRC32C hashing algorithm",
+      "install_id": "google-crc32c",
+      "license": "[ Apache-2.0 ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "name": "python3.11-google-crc32c-1.6.0",
+      "pname": "google-crc32c",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "0.14.5",
+      "version": "python3.11-google-crc32c-1.6.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/yc1i3xn1aj5abcigi4h3yhr1migrb8wy-gum-0.14.5"
+        "dist": "/nix/store/g058jaa06lcq5py19iki2spfmh99qz85-python3.11-google-crc32c-1.6.0-dist",
+        "out": "/nix/store/kw5b9v37ab50yl4swgdhgdls9d2gqw90-python3.11-google-crc32c-1.6.0"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
       "priority": 5
     },
     {
-      "attr_path": "gum",
+      "attr_path": "python311Packages.google-crc32c",
       "broken": false,
-      "derivation": "/nix/store/l9ln22mwn0x5rfffr8aa2zylwby9kzkw-gum-0.14.5.drv",
-      "description": "Tasty Bubble Gum for your shell",
-      "install_id": "gum",
-      "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
-      "name": "gum-0.14.5",
-      "pname": "gum",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "derivation": "/nix/store/26rikar0q5b1jlx472kcziqc9aqwjpfj-python3.11-google-crc32c-1.6.0.drv",
+      "description": "Wrapper the google/crc32c hardware-based implementation of the CRC32C hashing algorithm",
+      "install_id": "google-crc32c",
+      "license": "[ Apache-2.0 ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "name": "python3.11-google-crc32c-1.6.0",
+      "pname": "google-crc32c",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "0.14.5",
+      "version": "python3.11-google-crc32c-1.6.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/n7hrvg1wi6li9kaa1jgknnbdyzpa2kwz-gum-0.14.5"
+        "dist": "/nix/store/8qhwd1qa5ahljps2188mqvz95gffrp9f-python3.11-google-crc32c-1.6.0-dist",
+        "out": "/nix/store/k023hkidwbwb5xygz89q6xf3b39klsxn-python3.11-google-crc32c-1.6.0"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
       "priority": 5
     },
     {
-      "attr_path": "gum",
+      "attr_path": "python311Packages.google-crc32c",
       "broken": false,
-      "derivation": "/nix/store/rgfzq95bw2rzmvc9swv2nq9qwa7zr6w9-gum-0.14.5.drv",
-      "description": "Tasty Bubble Gum for your shell",
-      "install_id": "gum",
-      "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
-      "name": "gum-0.14.5",
-      "pname": "gum",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "derivation": "/nix/store/83bzhfjb1x1z3grz2yglyysr0qyy6237-python3.11-google-crc32c-1.6.0.drv",
+      "description": "Wrapper the google/crc32c hardware-based implementation of the CRC32C hashing algorithm",
+      "install_id": "google-crc32c",
+      "license": "[ Apache-2.0 ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "name": "python3.11-google-crc32c-1.6.0",
+      "pname": "google-crc32c",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "0.14.5",
+      "version": "python3.11-google-crc32c-1.6.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/962s45naidrx79v7p0q94xg5s2aq7i6v-gum-0.14.5"
+        "dist": "/nix/store/gj857rkhlggm1dzchcyyxzba84vrpx6z-python3.11-google-crc32c-1.6.0-dist",
+        "out": "/nix/store/sd63viysla3h3z6qyasc43n27x2fccjr-python3.11-google-crc32c-1.6.0"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
       "priority": 5
     },
     {
-      "attr_path": "gum",
+      "attr_path": "python311Packages.google-crc32c",
       "broken": false,
-      "derivation": "/nix/store/0fginxfwrx3q9b8ahzhzkgfi84cjzwy4-gum-0.14.5.drv",
-      "description": "Tasty Bubble Gum for your shell",
-      "install_id": "gum",
-      "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
-      "name": "gum-0.14.5",
-      "pname": "gum",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "derivation": "/nix/store/85i2lxr3ajsd19441371br93if26q3f8-python3.11-google-crc32c-1.6.0.drv",
+      "description": "Wrapper the google/crc32c hardware-based implementation of the CRC32C hashing algorithm",
+      "install_id": "google-crc32c",
+      "license": "[ Apache-2.0 ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "name": "python3.11-google-crc32c-1.6.0",
+      "pname": "google-crc32c",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "0.14.5",
+      "version": "python3.11-google-crc32c-1.6.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/0bsz576va04hm8fgpsjlspjclmc1wkik-gum-0.14.5"
+        "dist": "/nix/store/b5s1gng7plis3dn8ixkw5hg1xp7ypbp6-python3.11-google-crc32c-1.6.0-dist",
+        "out": "/nix/store/zkvsc5clfs5glcbhmybhx1wxsqywkm9p-python3.11-google-crc32c-1.6.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -575,17 +588,17 @@
     {
       "attr_path": "neo4j",
       "broken": false,
-      "derivation": "/nix/store/hlbnin7xxr99dxiglwa0718kh049rylw-neo4j-5.24.2.drv",
+      "derivation": "/nix/store/4hpax42h8n5300sgg1lxzlbr9ab2hlpg-neo4j-5.24.2.drv",
       "description": "Highly scalable, robust (fully ACID) native graph database",
       "install_id": "neo4j",
       "license": "GPL-3.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "neo4j-5.24.2",
       "pname": "neo4j",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -596,7 +609,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/pjxnzcsifg38r9d5a4frpjbvmi0nrvxk-neo4j-5.24.2"
+        "out": "/nix/store/wjjn0w84lq3lfry7qk90ipscjl8zin36-neo4j-5.24.2"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -605,17 +618,17 @@
     {
       "attr_path": "neo4j",
       "broken": false,
-      "derivation": "/nix/store/y0yn102bv2nqppjg4nm0w39jsbar2a19-neo4j-5.24.2.drv",
+      "derivation": "/nix/store/0wdcy9kcdw2xlis4rjn8ggxzdn63gsiw-neo4j-5.24.2.drv",
       "description": "Highly scalable, robust (fully ACID) native graph database",
       "install_id": "neo4j",
       "license": "GPL-3.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "neo4j-5.24.2",
       "pname": "neo4j",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -626,7 +639,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/y06jrdyvwv88mvk74y11hx99r2b7p6zq-neo4j-5.24.2"
+        "out": "/nix/store/syk4j1xlm0jhnx9syiqndf18cnds46q5-neo4j-5.24.2"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -635,17 +648,17 @@
     {
       "attr_path": "neo4j",
       "broken": false,
-      "derivation": "/nix/store/0kpl5vlwiy6sa40ia6qp0q3wflwgpqkc-neo4j-5.24.2.drv",
+      "derivation": "/nix/store/3wi7rfdarbv697h1my7khqc7h7qr9h26-neo4j-5.24.2.drv",
       "description": "Highly scalable, robust (fully ACID) native graph database",
       "install_id": "neo4j",
       "license": "GPL-3.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "neo4j-5.24.2",
       "pname": "neo4j",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -656,7 +669,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/s8vdlg9l61pgnj19rr2jz5v02kap47nm-neo4j-5.24.2"
+        "out": "/nix/store/3rvrqpjmx7sqxc09cb6lrkxhif5gvwwx-neo4j-5.24.2"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -665,17 +678,17 @@
     {
       "attr_path": "neo4j",
       "broken": false,
-      "derivation": "/nix/store/3jd5davz58kx0ic58is97piqp4pv3kqs-neo4j-5.24.2.drv",
+      "derivation": "/nix/store/bwh2hrp1ghyp48j10bdvawhnx110klf5-neo4j-5.24.2.drv",
       "description": "Highly scalable, robust (fully ACID) native graph database",
       "install_id": "neo4j",
       "license": "GPL-3.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "neo4j-5.24.2",
       "pname": "neo4j",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -686,7 +699,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/2cbima78n2h55ihdqn8krmm2k3fzbv1q-neo4j-5.24.2"
+        "out": "/nix/store/qskir323k2a5lmrx9vr4c7abmrxlb2ww-neo4j-5.24.2"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -695,17 +708,17 @@
     {
       "attr_path": "nodejs",
       "broken": false,
-      "derivation": "/nix/store/yz8yjgl9xs9gbk4y2ar44lng9vxnk454-nodejs-20.18.0.drv",
+      "derivation": "/nix/store/v0v7dny82f4hmfp9s8zj31iykjrdblkn-nodejs-20.18.0.drv",
       "description": "Event-driven I/O framework for the V8 JavaScript engine",
       "install_id": "nodejs",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "nodejs-20.18.0",
       "pname": "nodejs",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -716,8 +729,8 @@
         "out"
       ],
       "outputs": {
-        "libv8": "/nix/store/0x38rb1l2fp5k1765pxw9jsxamcmq06n-nodejs-20.18.0-libv8",
-        "out": "/nix/store/n3yy2py144i01235yqq6ps3ah5dkynx2-nodejs-20.18.0"
+        "libv8": "/nix/store/hfchgw1as9fm02wcyr3iqya05ylll5f3-nodejs-20.18.0-libv8",
+        "out": "/nix/store/9grahx8677nlgbx3yfiggibw335lkgfr-nodejs-20.18.0"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -726,17 +739,17 @@
     {
       "attr_path": "nodejs",
       "broken": false,
-      "derivation": "/nix/store/wb39s2j0p6bmynhvrrsbmayq1dal4pyn-nodejs-20.18.0.drv",
+      "derivation": "/nix/store/d3mn4dx774ppvnajxls24jkgsscv4sq5-nodejs-20.18.0.drv",
       "description": "Event-driven I/O framework for the V8 JavaScript engine",
       "install_id": "nodejs",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "nodejs-20.18.0",
       "pname": "nodejs",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -747,8 +760,8 @@
         "out"
       ],
       "outputs": {
-        "libv8": "/nix/store/b64y4904jda3vi487yrvk2ls1rkg30xm-nodejs-20.18.0-libv8",
-        "out": "/nix/store/p4kpvfr95znlbh61nwlwcdfc7gkcyngl-nodejs-20.18.0"
+        "libv8": "/nix/store/yajvza262cb3bri9cryfrgpm3pvc066n-nodejs-20.18.0-libv8",
+        "out": "/nix/store/hsh74yzdb9yk834w9j5qz0w3sw84wcfv-nodejs-20.18.0"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -757,17 +770,17 @@
     {
       "attr_path": "nodejs",
       "broken": false,
-      "derivation": "/nix/store/3gqhy6sig3vbb8i9xql7mya9732mgsk0-nodejs-20.18.0.drv",
+      "derivation": "/nix/store/lmn1hdq8i3gf5d3r64l13nhanlb2pnx5-nodejs-20.18.0.drv",
       "description": "Event-driven I/O framework for the V8 JavaScript engine",
       "install_id": "nodejs",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "nodejs-20.18.0",
       "pname": "nodejs",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -778,8 +791,8 @@
         "out"
       ],
       "outputs": {
-        "libv8": "/nix/store/sjs2syzk35xqm9jif9hp1rjd82irzkil-nodejs-20.18.0-libv8",
-        "out": "/nix/store/m1ymz3alwqc71yrmzl8sas2m8ksqhhsh-nodejs-20.18.0"
+        "libv8": "/nix/store/93xdzgjsm1dnnw33lnba4i7h7k5yph4k-nodejs-20.18.0-libv8",
+        "out": "/nix/store/v8p36abnvrn9i5h41zkgrayaj7sclv6z-nodejs-20.18.0"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -788,17 +801,17 @@
     {
       "attr_path": "nodejs",
       "broken": false,
-      "derivation": "/nix/store/02a7604ac95ibdih8a1gakfzpcvkxh1x-nodejs-20.18.0.drv",
+      "derivation": "/nix/store/l136ajs6lg3mic58rnb7cdwhfhl3qcyr-nodejs-20.18.0.drv",
       "description": "Event-driven I/O framework for the V8 JavaScript engine",
       "install_id": "nodejs",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "nodejs-20.18.0",
       "pname": "nodejs",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -809,8 +822,8 @@
         "out"
       ],
       "outputs": {
-        "libv8": "/nix/store/30a0s87x6bjvcd2fjpvg5safq58z80as-nodejs-20.18.0-libv8",
-        "out": "/nix/store/jz54v1m0ldqivx5i45q8i05pz5clf842-nodejs-20.18.0"
+        "libv8": "/nix/store/czcxwki3zqih2pf355zk0vxbmrij2bzx-nodejs-20.18.0-libv8",
+        "out": "/nix/store/z0ivg3dbal4sk5h0c7p1pfkxc7ff98ri-nodejs-20.18.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -819,17 +832,17 @@
     {
       "attr_path": "ollama",
       "broken": false,
-      "derivation": "/nix/store/wid7vdlvp1gjybavln4crfwkcws7x6ph-ollama-0.3.12.drv",
+      "derivation": "/nix/store/046q4ff0a5nsahzn254z0c7cx5gav61q-ollama-0.3.12.drv",
       "description": "Get up and running with large language models locally",
       "install_id": "ollama",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "ollama-0.3.12",
       "pname": "ollama",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -840,7 +853,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/4jljlfaqh9im76bizwrw6chnkkm8l329-ollama-0.3.12"
+        "out": "/nix/store/csz5wdxywyl9cblrr3g2ydr8b0fxs7h5-ollama-0.3.12"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -849,17 +862,17 @@
     {
       "attr_path": "ollama",
       "broken": false,
-      "derivation": "/nix/store/m9nn8w6n21fjk2w0nlgk8g0f0lyz4mnn-ollama-0.3.12.drv",
+      "derivation": "/nix/store/wzppbi2bfvc15dfb0r0ykpdp7pf1irx5-ollama-0.3.12.drv",
       "description": "Get up and running with large language models locally",
       "install_id": "ollama",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "ollama-0.3.12",
       "pname": "ollama",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -870,7 +883,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/dszlnvrilmp466rirnw62j65rqd1i8pk-ollama-0.3.12"
+        "out": "/nix/store/2xqa8r487c79kvqw97br2y2nyjs7jbf9-ollama-0.3.12"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -879,17 +892,17 @@
     {
       "attr_path": "ollama",
       "broken": false,
-      "derivation": "/nix/store/qkzq7ydsnnm93imvr7c7p5zpxk5b0abh-ollama-0.3.12.drv",
+      "derivation": "/nix/store/w3sgjymwsm04b37646rvyfmscnabmjdq-ollama-0.3.12.drv",
       "description": "Get up and running with large language models locally",
       "install_id": "ollama",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "ollama-0.3.12",
       "pname": "ollama",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -900,7 +913,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/10j8llcsf973x91bhvbpmxm58yswlnya-ollama-0.3.12"
+        "out": "/nix/store/jdmp95bxckyrgm0qjjsxayh67v3d36y4-ollama-0.3.12"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -909,17 +922,17 @@
     {
       "attr_path": "ollama",
       "broken": false,
-      "derivation": "/nix/store/wfr3ymbq0hk0j520y1zqas3q3pdy98b3-ollama-0.3.12.drv",
+      "derivation": "/nix/store/6jv0zwapr4x1qywy0f3ikqp8zd9nnv65-ollama-0.3.12.drv",
       "description": "Get up and running with large language models locally",
       "install_id": "ollama",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "ollama-0.3.12",
       "pname": "ollama",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -930,7 +943,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/18garj9lhsxlbnin38h16l2k0db8fn6h-ollama-0.3.12"
+        "out": "/nix/store/ni4aips26azgkbzfg3b12r49c239dykq-ollama-0.3.12"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -939,17 +952,17 @@
     {
       "attr_path": "pkg-config",
       "broken": false,
-      "derivation": "/nix/store/ix8a19h839iin8kvwzd74c25r6qnvvp2-pkg-config-wrapper-0.29.2.drv",
+      "derivation": "/nix/store/1jc5p7m1gf1sfhafw36j77q89fxns6xf-pkg-config-wrapper-0.29.2.drv",
       "description": "Tool that allows packages to find out information about other packages (wrapper script)",
       "install_id": "pkg-config",
       "license": "GPL-2.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "pkg-config-wrapper-0.29.2",
       "pname": "pkg-config",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -961,9 +974,9 @@
         "man"
       ],
       "outputs": {
-        "doc": "/nix/store/8wr56pmzdw73b63dm2d1fan7gc5nhkyr-pkg-config-wrapper-0.29.2-doc",
-        "man": "/nix/store/0b641cfw7zrg47c3m0b196swhy5kadv0-pkg-config-wrapper-0.29.2-man",
-        "out": "/nix/store/gvgay2fp27k7rr03lf3m572gcd9f7gdy-pkg-config-wrapper-0.29.2"
+        "doc": "/nix/store/pmigd0r84hg4qnww2s24avkwrmgpyzp2-pkg-config-wrapper-0.29.2-doc",
+        "man": "/nix/store/pcfhhyk7rqhhkqy7848p10mjn9fzfc07-pkg-config-wrapper-0.29.2-man",
+        "out": "/nix/store/c6v2ngygy55zamyz17z94brbz2vrsi1z-pkg-config-wrapper-0.29.2"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -972,17 +985,17 @@
     {
       "attr_path": "pkg-config",
       "broken": false,
-      "derivation": "/nix/store/1hnzfl8hpkgccyljiarqixrc68489pb5-pkg-config-wrapper-0.29.2.drv",
+      "derivation": "/nix/store/yvbvcx864226rg7xpbk8nbrr51lrd62z-pkg-config-wrapper-0.29.2.drv",
       "description": "Tool that allows packages to find out information about other packages (wrapper script)",
       "install_id": "pkg-config",
       "license": "GPL-2.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "pkg-config-wrapper-0.29.2",
       "pname": "pkg-config",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -994,9 +1007,9 @@
         "man"
       ],
       "outputs": {
-        "doc": "/nix/store/6dylih37y66i4pfr12y224314yj5z6ab-pkg-config-wrapper-0.29.2-doc",
-        "man": "/nix/store/pcwn5pa0rg4bpb17mcsnppjmsshq4y03-pkg-config-wrapper-0.29.2-man",
-        "out": "/nix/store/4jksdlwv777xw9s1k9q89ch0m0i8ngkg-pkg-config-wrapper-0.29.2"
+        "doc": "/nix/store/y2c1zygpklpmcvwffbhd6ka53x29pdj9-pkg-config-wrapper-0.29.2-doc",
+        "man": "/nix/store/pbkvbqvb34ambadx8ak05gf9z3k6n6li-pkg-config-wrapper-0.29.2-man",
+        "out": "/nix/store/r0yy5v0hb9q0y3k4r98jjy3z5q332xv8-pkg-config-wrapper-0.29.2"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -1005,17 +1018,17 @@
     {
       "attr_path": "pkg-config",
       "broken": false,
-      "derivation": "/nix/store/1g9v0m5n6jc4c5vdkjqcm39vfqh3hk4r-pkg-config-wrapper-0.29.2.drv",
+      "derivation": "/nix/store/2svva29wwq59wwgwrxi0zbqs80glqfcw-pkg-config-wrapper-0.29.2.drv",
       "description": "Tool that allows packages to find out information about other packages (wrapper script)",
       "install_id": "pkg-config",
       "license": "GPL-2.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "pkg-config-wrapper-0.29.2",
       "pname": "pkg-config",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -1027,9 +1040,9 @@
         "man"
       ],
       "outputs": {
-        "doc": "/nix/store/7v7z52l1254ax8xi9fa44saxa7x6padj-pkg-config-wrapper-0.29.2-doc",
-        "man": "/nix/store/hjy149dg0dpc70rg808xl6wb4d1ifddl-pkg-config-wrapper-0.29.2-man",
-        "out": "/nix/store/w3v162l2j46bpjbcxk5rxbszl0w2jxc4-pkg-config-wrapper-0.29.2"
+        "doc": "/nix/store/fjhch1gy7yajsf3g25jahhj54dpyqljh-pkg-config-wrapper-0.29.2-doc",
+        "man": "/nix/store/x185axgbaz47kxqpk7714h400543ln38-pkg-config-wrapper-0.29.2-man",
+        "out": "/nix/store/7spy1pbif3par1zk0n9y1f8rn2rb67yc-pkg-config-wrapper-0.29.2"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -1038,17 +1051,17 @@
     {
       "attr_path": "pkg-config",
       "broken": false,
-      "derivation": "/nix/store/jp0cg2dkzq50rf87adgiyipdfd5r9dy8-pkg-config-wrapper-0.29.2.drv",
+      "derivation": "/nix/store/5xf27zalc62awyx5y6byxl2dib8lxnfv-pkg-config-wrapper-0.29.2.drv",
       "description": "Tool that allows packages to find out information about other packages (wrapper script)",
       "install_id": "pkg-config",
       "license": "GPL-2.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "pkg-config-wrapper-0.29.2",
       "pname": "pkg-config",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -1060,9 +1073,9 @@
         "man"
       ],
       "outputs": {
-        "doc": "/nix/store/298y781q85m9j897jx81imp7hn8aand2-pkg-config-wrapper-0.29.2-doc",
-        "man": "/nix/store/b1905yvqnz996zrzzpnysgd05l9r2l1k-pkg-config-wrapper-0.29.2-man",
-        "out": "/nix/store/946chn5ja4yrvnnc5izwv792cc57xpy8-pkg-config-wrapper-0.29.2"
+        "doc": "/nix/store/42q995i0pk7mi79h32r2fc7v1fw8la4d-pkg-config-wrapper-0.29.2-doc",
+        "man": "/nix/store/xnwya1zw4x0zm0k5s9fiabzf9qw7ibxa-pkg-config-wrapper-0.29.2-man",
+        "out": "/nix/store/f1gamyykr0f8n4afy910ass2jx2g9zkv-pkg-config-wrapper-0.29.2"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -1071,17 +1084,17 @@
     {
       "attr_path": "poppler_utils",
       "broken": false,
-      "derivation": "/nix/store/5h42857ivhi57ajrf1isw8b284myfmx6-poppler-utils-24.02.0.drv",
+      "derivation": "/nix/store/f6905gnhqqwr07ywrf7qqj8vw15jbs5f-poppler-utils-24.02.0.drv",
       "description": "PDF rendering library",
       "install_id": "poppler_utils",
       "license": "GPL-2.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "poppler-utils-24.02.0",
       "pname": "poppler_utils",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -1092,8 +1105,8 @@
         "out"
       ],
       "outputs": {
-        "dev": "/nix/store/ljpdq6kan55lspwfh859gz5pkc4gzw8w-poppler-utils-24.02.0-dev",
-        "out": "/nix/store/3ks25yjv2xgxx80bv2i5h7avlfibs8xj-poppler-utils-24.02.0"
+        "dev": "/nix/store/kp4fxb650p588y3jwn9gc66wnh7pnf4z-poppler-utils-24.02.0-dev",
+        "out": "/nix/store/yz43734ghhirj7wawv0sikj4hnnh1yg6-poppler-utils-24.02.0"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -1102,17 +1115,17 @@
     {
       "attr_path": "poppler_utils",
       "broken": false,
-      "derivation": "/nix/store/9dva0sknzzm471cpizlw3kxdbqw43k81-poppler-utils-24.02.0.drv",
+      "derivation": "/nix/store/a9f0bd4h3isdynqrrp9fxsyr1m7m1fm0-poppler-utils-24.02.0.drv",
       "description": "PDF rendering library",
       "install_id": "poppler_utils",
       "license": "GPL-2.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "poppler-utils-24.02.0",
       "pname": "poppler_utils",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -1123,8 +1136,8 @@
         "out"
       ],
       "outputs": {
-        "dev": "/nix/store/2lc9qfijris4h4y4bb9wc5ij46apjzkh-poppler-utils-24.02.0-dev",
-        "out": "/nix/store/qjc9349mx5h6w6vww1spskzaigwci46b-poppler-utils-24.02.0"
+        "dev": "/nix/store/7439h4gvh3amj9rnzxi1pfb0nyal0avd-poppler-utils-24.02.0-dev",
+        "out": "/nix/store/dnmcl7wm4gxjmd1sllk9cqk83mhncab9-poppler-utils-24.02.0"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -1133,17 +1146,17 @@
     {
       "attr_path": "poppler_utils",
       "broken": false,
-      "derivation": "/nix/store/v7yjxkn1vg04pdzywq4vf27vazilrrd3-poppler-utils-24.02.0.drv",
+      "derivation": "/nix/store/3mi7v5bqw8rgnn8js6jq5hy86v8dqi5y-poppler-utils-24.02.0.drv",
       "description": "PDF rendering library",
       "install_id": "poppler_utils",
       "license": "GPL-2.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "poppler-utils-24.02.0",
       "pname": "poppler_utils",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -1154,8 +1167,8 @@
         "out"
       ],
       "outputs": {
-        "dev": "/nix/store/a900y5675wd3la1p404igc7kxz4hrvw5-poppler-utils-24.02.0-dev",
-        "out": "/nix/store/g5l1qbmbfczalc19zqj4mkhi4i6cm27f-poppler-utils-24.02.0"
+        "dev": "/nix/store/j0n2ylm1bqr5lq8d01wwg246dq4b1wxb-poppler-utils-24.02.0-dev",
+        "out": "/nix/store/rmi07m1yyg2xz0j7hr5rmk6c3yv61hcv-poppler-utils-24.02.0"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -1164,17 +1177,17 @@
     {
       "attr_path": "poppler_utils",
       "broken": false,
-      "derivation": "/nix/store/l12h7n6p1mhp960pgss150zjwg1kbq7v-poppler-utils-24.02.0.drv",
+      "derivation": "/nix/store/7fbhgpw25v1k0c1nbyjr31j501cbfy8k-poppler-utils-24.02.0.drv",
       "description": "PDF rendering library",
       "install_id": "poppler_utils",
       "license": "GPL-2.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "poppler-utils-24.02.0",
       "pname": "poppler_utils",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -1185,250 +1198,374 @@
         "out"
       ],
       "outputs": {
-        "dev": "/nix/store/zwrxnzg33ch8qrgfvmnwz4hjicz42h7m-poppler-utils-24.02.0-dev",
-        "out": "/nix/store/z227kjngla4l7jn7a5719izxqrmm7vpw-poppler-utils-24.02.0"
+        "dev": "/nix/store/97m384a2bl7y2l664mbvnpy9wi2imw0p-poppler-utils-24.02.0-dev",
+        "out": "/nix/store/l01smbhhj58svfc5slvpja9d18mv9qw7-poppler-utils-24.02.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
       "priority": 5
     },
     {
-      "attr_path": "python3",
+      "attr_path": "python311",
       "broken": false,
-      "derivation": "/nix/store/nfqzgvmajgyf3h5hchs03ngs99h0zaqn-python3-3.12.7.drv",
+      "derivation": "/nix/store/pva5isirp5dshkfdihindi5nczd8ygsq-python3-3.11.10.drv",
       "description": "High-level dynamically-typed programming language",
-      "install_id": "python3",
+      "install_id": "python",
       "license": "Python-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
-      "name": "python3-3.12.7",
-      "pname": "python3",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "name": "python3-3.11.10",
+      "pname": "python311",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "3.12.7",
+      "version": "python3-3.11.10",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/2djmffykchgm4q4j7ylv7xgkg441mp2j-python3-3.12.7"
+        "out": "/nix/store/qw9bwqbwcai9iaqiyir18knz91sff9am-python3-3.11.10"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 0
+    },
+    {
+      "attr_path": "python311",
+      "broken": false,
+      "derivation": "/nix/store/z4sxipp3nc8lhs5vh7bp7gi8vr1248d7-python3-3.11.10.drv",
+      "description": "High-level dynamically-typed programming language",
+      "install_id": "python",
+      "license": "Python-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "name": "python3-3.11.10",
+      "pname": "python311",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "python3-3.11.10",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "debug": "/nix/store/mkhy5l0xyj8hxq58nkfxp0yl9i5adls7-python3-3.11.10-debug",
+        "out": "/nix/store/9q4bq9grl6cxgakbi4aj8w8hp3x3vf29-python3-3.11.10"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 0
+    },
+    {
+      "attr_path": "python311",
+      "broken": false,
+      "derivation": "/nix/store/gksklr87512i5p1wjg0ad7jncmxqxjpn-python3-3.11.10.drv",
+      "description": "High-level dynamically-typed programming language",
+      "install_id": "python",
+      "license": "Python-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "name": "python3-3.11.10",
+      "pname": "python311",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "python3-3.11.10",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/291hgygyzl786kbyzs3svlqplxs9rr4m-python3-3.11.10"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 0
+    },
+    {
+      "attr_path": "python311",
+      "broken": false,
+      "derivation": "/nix/store/a4i1pggv858j6h8nqlqacw1jkb6yb8ik-python3-3.11.10.drv",
+      "description": "High-level dynamically-typed programming language",
+      "install_id": "python",
+      "license": "Python-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "name": "python3-3.11.10",
+      "pname": "python311",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "python3-3.11.10",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "debug": "/nix/store/agpz5hvhh2hz1rc29iksvc1zb36v483s-python3-3.11.10-debug",
+        "out": "/nix/store/igyzv5c2v672mhmx1ha1i7062y6rggqs-python3-3.11.10"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 0
+    },
+    {
+      "attr_path": "tesseract",
+      "broken": false,
+      "derivation": "/nix/store/1lf579xwjfrwlz3cymmw23w9svlam0js-tesseract-5.3.4.drv",
+      "description": "OCR engine",
+      "install_id": "tesseract",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "name": "tesseract-5.3.4",
+      "pname": "tesseract",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "5.3.4",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/60fr35x3g2g5br5ij7p87c5l9vgifyr8-tesseract-5.3.4"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
       "priority": 5
     },
     {
-      "attr_path": "python3",
+      "attr_path": "tesseract",
       "broken": false,
-      "derivation": "/nix/store/nrwf0ar2p6wrx17vvs9zfmllkn1p1gqh-python3-3.12.7.drv",
-      "description": "High-level dynamically-typed programming language",
-      "install_id": "python3",
-      "license": "Python-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
-      "name": "python3-3.12.7",
-      "pname": "python3",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "derivation": "/nix/store/bjcqn1plmjr6s2mkhnfzm7z10yq8r3zr-tesseract-5.3.4.drv",
+      "description": "OCR engine",
+      "install_id": "tesseract",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "name": "tesseract-5.3.4",
+      "pname": "tesseract",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "3.12.7",
+      "version": "5.3.4",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "debug": "/nix/store/i2dk7l0b260px2i3v751z12kh6fkanzw-python3-3.12.7-debug",
-        "out": "/nix/store/zkzg2gaacmhc2i9ggp35dbl5x0y49531-python3-3.12.7"
+        "out": "/nix/store/c4hdwfznlkj9ynghh1k3nzp9jmhwgc8p-tesseract-5.3.4"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
       "priority": 5
     },
     {
-      "attr_path": "python3",
+      "attr_path": "tesseract",
       "broken": false,
-      "derivation": "/nix/store/8xdxhcf5yh5p4rc1b8i3g0z3bq52kv46-python3-3.12.7.drv",
-      "description": "High-level dynamically-typed programming language",
-      "install_id": "python3",
-      "license": "Python-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
-      "name": "python3-3.12.7",
-      "pname": "python3",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "derivation": "/nix/store/fn3qiq62jjr8jsfkggg6zznp4ywwyjcl-tesseract-5.3.4.drv",
+      "description": "OCR engine",
+      "install_id": "tesseract",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "name": "tesseract-5.3.4",
+      "pname": "tesseract",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "3.12.7",
+      "version": "5.3.4",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/70ifxn668cb1y4yiy35v0g8ic1wg33cz-python3-3.12.7"
+        "out": "/nix/store/h3587pmkgrpxl2grbq4l48pax2pirh2x-tesseract-5.3.4"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
       "priority": 5
     },
     {
-      "attr_path": "python3",
+      "attr_path": "tesseract",
       "broken": false,
-      "derivation": "/nix/store/97s6qwipyppnh12dayv0k3qml0xb5dsq-python3-3.12.7.drv",
-      "description": "High-level dynamically-typed programming language",
-      "install_id": "python3",
-      "license": "Python-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
-      "name": "python3-3.12.7",
-      "pname": "python3",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "derivation": "/nix/store/m1pi3rc1jn2knld8p6k8986l7qaa8wsl-tesseract-5.3.4.drv",
+      "description": "OCR engine",
+      "install_id": "tesseract",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "name": "tesseract-5.3.4",
+      "pname": "tesseract",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "3.12.7",
+      "version": "5.3.4",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "debug": "/nix/store/1qffxia2lrnwa8pcwbl1hk4i5v5xagcj-python3-3.12.7-debug",
-        "out": "/nix/store/901c80rlps5q05bnjk1sj4zaz5k736nc-python3-3.12.7"
+        "out": "/nix/store/3cgaxqnpd7kaqva65ixvjrmcpjz2fnz2-tesseract-5.3.4"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
       "priority": 5
     },
     {
-      "attr_path": "tesseract",
+      "attr_path": "uv",
       "broken": false,
-      "derivation": "/nix/store/zjljm05b3qqqj1a41cymqfirw1hfzzr2-tesseract-5.3.4.drv",
-      "description": "OCR engine",
-      "install_id": "tesseract",
-      "license": "Apache-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
-      "name": "tesseract-5.3.4",
-      "pname": "tesseract",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "derivation": "/nix/store/4bw3qrcfcyyrnx2v77xf0vi0xf9sknpa-uv-0.4.30.drv",
+      "description": "Extremely fast Python package installer and resolver, written in Rust",
+      "install_id": "uv",
+      "license": "[ Apache-2.0, MIT ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "name": "uv-0.4.30",
+      "pname": "uv",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "5.3.4",
+      "version": "0.4.30",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/blg2p7w4706ar34h3irbl16qidaajpvv-tesseract-5.3.4"
+        "dist": "/nix/store/fkyqi24vxxcz8q1q312d0a4nv7ch391m-uv-0.4.30-dist",
+        "out": "/nix/store/yvdr8x3lfq0m669l7vznyjg51259vzl4-uv-0.4.30"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
       "priority": 5
     },
     {
-      "attr_path": "tesseract",
+      "attr_path": "uv",
       "broken": false,
-      "derivation": "/nix/store/q5iqk34q6bf1kg166b9xagxplh6zxkyh-tesseract-5.3.4.drv",
-      "description": "OCR engine",
-      "install_id": "tesseract",
-      "license": "Apache-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
-      "name": "tesseract-5.3.4",
-      "pname": "tesseract",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "derivation": "/nix/store/4ml6q6rbm3csw3f2358gdmvc3h644mda-uv-0.4.30.drv",
+      "description": "Extremely fast Python package installer and resolver, written in Rust",
+      "install_id": "uv",
+      "license": "[ Apache-2.0, MIT ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "name": "uv-0.4.30",
+      "pname": "uv",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "5.3.4",
+      "version": "0.4.30",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/sk57k9ipfd8azlzbzmiv1v2h9k76mqas-tesseract-5.3.4"
+        "dist": "/nix/store/8azyzcr9la6w8598m1bn3rx5ql148iqq-uv-0.4.30-dist",
+        "out": "/nix/store/d21lwf3jwshn24krhsfmwxslxwikyw8k-uv-0.4.30"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
       "priority": 5
     },
     {
-      "attr_path": "tesseract",
+      "attr_path": "uv",
       "broken": false,
-      "derivation": "/nix/store/gybsc1vnyq24bkvr87idh3n7fzkpc4qi-tesseract-5.3.4.drv",
-      "description": "OCR engine",
-      "install_id": "tesseract",
-      "license": "Apache-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
-      "name": "tesseract-5.3.4",
-      "pname": "tesseract",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "derivation": "/nix/store/wccymia2l9q26yf0fcskq8d95s3jx30m-uv-0.4.30.drv",
+      "description": "Extremely fast Python package installer and resolver, written in Rust",
+      "install_id": "uv",
+      "license": "[ Apache-2.0, MIT ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "name": "uv-0.4.30",
+      "pname": "uv",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "5.3.4",
+      "version": "0.4.30",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/xzqspc6q96hfz291mg1q5224vvv2v2qq-tesseract-5.3.4"
+        "dist": "/nix/store/r5fk3v7s1fm82hsblajmh2j1cp317bz5-uv-0.4.30-dist",
+        "out": "/nix/store/534fmkacb1qxw4mv0zqjm7hh732ip4fi-uv-0.4.30"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
       "priority": 5
     },
     {
-      "attr_path": "tesseract",
+      "attr_path": "uv",
       "broken": false,
-      "derivation": "/nix/store/rxfxwxhmhb9mbmcmfqjivm0c58lxmwxc-tesseract-5.3.4.drv",
-      "description": "OCR engine",
-      "install_id": "tesseract",
-      "license": "Apache-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
-      "name": "tesseract-5.3.4",
-      "pname": "tesseract",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "derivation": "/nix/store/r32ga1dwq6x6l4fckkfil4aqq6wzyir4-uv-0.4.30.drv",
+      "description": "Extremely fast Python package installer and resolver, written in Rust",
+      "install_id": "uv",
+      "license": "[ Apache-2.0, MIT ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "name": "uv-0.4.30",
+      "pname": "uv",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "5.3.4",
+      "version": "0.4.30",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/dla8g8lpkv22nkdklvwdpqs8dab722mr-tesseract-5.3.4"
+        "dist": "/nix/store/ys3ydh0p7ir68m81v3yqyh4aqjpyk1rb-uv-0.4.30-dist",
+        "out": "/nix/store/plgmjfks0wb6v307dixvvcq5w4vldjzz-uv-0.4.30"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -1437,17 +1574,17 @@
     {
       "attr_path": "yarn",
       "broken": false,
-      "derivation": "/nix/store/cz1pk0sam061n4wnpl3ka8i661x3csgg-yarn-1.22.22.drv",
+      "derivation": "/nix/store/29jq3h1xvi33nid9na3bimxaff8bf67z-yarn-1.22.22.drv",
       "description": "Fast, reliable, and secure dependency management for javascript",
       "install_id": "yarn",
       "license": "BSD-2-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "yarn-1.22.22",
       "pname": "yarn",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -1458,7 +1595,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/yd2i0x6pvxbcyrwj8bjr6xq88cpr3ac6-yarn-1.22.22"
+        "out": "/nix/store/0hmmpszg5wfrr43kvlk2cxjqpll0dh2z-yarn-1.22.22"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -1467,17 +1604,17 @@
     {
       "attr_path": "yarn",
       "broken": false,
-      "derivation": "/nix/store/xdawn8bjk20ffzl7p1a6f0vagq00j64a-yarn-1.22.22.drv",
+      "derivation": "/nix/store/vkm27crcfnsh8jvrvpi4bs2k67mb9b2z-yarn-1.22.22.drv",
       "description": "Fast, reliable, and secure dependency management for javascript",
       "install_id": "yarn",
       "license": "BSD-2-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "yarn-1.22.22",
       "pname": "yarn",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -1488,7 +1625,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/xph2b7ri9ixs1kr7qg9zlksmf86prcqn-yarn-1.22.22"
+        "out": "/nix/store/vmx0di4y3m8amqwsfgyccf8zs8kml06q-yarn-1.22.22"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -1497,17 +1634,17 @@
     {
       "attr_path": "yarn",
       "broken": false,
-      "derivation": "/nix/store/07ch5spqqmqbywljb6ml07ajpiqlqszk-yarn-1.22.22.drv",
+      "derivation": "/nix/store/rxkhv6b9iarrklhib18vnr8sj5428bxr-yarn-1.22.22.drv",
       "description": "Fast, reliable, and secure dependency management for javascript",
       "install_id": "yarn",
       "license": "BSD-2-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "yarn-1.22.22",
       "pname": "yarn",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -1518,7 +1655,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/db3fkh9fqmq4qcslp32p7436c6q4738q-yarn-1.22.22"
+        "out": "/nix/store/nbaa0rip3xw6l3bmnc2k2fm071pzvzwv-yarn-1.22.22"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -1527,17 +1664,17 @@
     {
       "attr_path": "yarn",
       "broken": false,
-      "derivation": "/nix/store/q994dzagxwkzgqwpc2iix141pzx9sbsd-yarn-1.22.22.drv",
+      "derivation": "/nix/store/7bxc3x8jz6jbrg5gi2qlz1cffzgrba3a-yarn-1.22.22.drv",
       "description": "Fast, reliable, and secure dependency management for javascript",
       "install_id": "yarn",
       "license": "BSD-2-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=dc460ec76cbff0e66e269457d7b728432263166c",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=23e89b7da85c3640bbc2173fe04f4bd114342367",
       "name": "yarn-1.22.22",
       "pname": "yarn",
-      "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
-      "rev_count": 706477,
-      "rev_date": "2024-11-11T10:11:37Z",
-      "scrape_date": "2024-11-15T03:58:27Z",
+      "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+      "rev_count": 710087,
+      "rev_date": "2024-11-19T11:04:08Z",
+      "scrape_date": "2024-11-21T04:00:36Z",
       "stabilities": [
         "staging",
         "unstable"
@@ -1548,7 +1685,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/fsyk2yniga62hvkyz45b6zqimnkb68zh-yarn-1.22.22"
+        "out": "/nix/store/hlf55dc9jjm9xhhjx29ll65ya1rzlmal-yarn-1.22.22"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -84,7 +84,7 @@
       "VITE_TIME_PER_PAGE": "50"
     },
     "hook": {
-      "on-activate": "  # If we export this here, it can be used later in 'profiles.common/bash'\n  export PYTHON_DIR=\"$FLOX_ENV_CACHE/python\"\n\n  test -d \"${PYTHON_DIR}\" \\\n    || uv venv \"${PYTHON_DIR}\" --allow-existing\n  source \"$PYTHON_DIR/bin/activate\"\n  \n  uv pip install -r backend/requirements.txt\n\n  yarn --cwd frontend install\n\n  ollama list | grep \"^llama3\" || ollama pull llama3\n"
+      "on-activate": "  # If we export this here, it can be used later in 'profiles.common/bash'\n  export PYTHON_DIR=\"$FLOX_ENV_CACHE/python\"\n\n  test -d \"${PYTHON_DIR}\" \\\n    || uv venv \"${PYTHON_DIR}\" --allow-existing\n  source \"$PYTHON_DIR/bin/activate\"\n  \n  uv pip install -r backend/requirements.txt\n\n  yarn --cwd frontend install\n"
     },
     "profile": {
       "bash": "source \"$PYTHON_DIR/bin/activate\"\n",
@@ -114,6 +114,13 @@
       },
       "frontend": {
         "command": "cd frontend\nyarn run dev\n",
+        "vars": null,
+        "is-daemon": null,
+        "shutdown": null,
+        "systems": null
+      },
+      "models": {
+        "command": "# wait for ollama to be ready\nuntil ollama list; do\n  sleep 0.1\ndone\n\nollama pull llama3:latest\n",
         "vars": null,
         "is-daemon": null,
         "shutdown": null,

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -89,6 +89,13 @@ on-activate = '''
   uv pip install -r backend/requirements.txt
 
   yarn --cwd frontend install
+
+  echo "
+  you can check the status of the llama3 model with:
+    flox services logs --follow models
+  or:
+    ollama list
+  "
 '''
 
 
@@ -130,7 +137,8 @@ until ollama list; do
   sleep 0.1
 done
 
-ollama pull llama3:latest
+ollama list | grep -q "^llama3" || \
+  ollama pull llama3:latest
 """
 
 [options]

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -89,8 +89,6 @@ on-activate = '''
   uv pip install -r backend/requirements.txt
 
   yarn --cwd frontend install
-
-  ollama list | grep "^llama3" || ollama pull llama3
 '''
 
 
@@ -125,6 +123,15 @@ python3 score.py
 ollama.command = '''
 ollama serve
 '''
+
+models.command = """
+# wait for ollama to be ready
+until ollama list; do
+  sleep 0.1
+done
+
+ollama pull llama3:latest
+"""
 
 [options]
 systems = ["aarch64-darwin", "aarch64-linux", "x86_64-darwin", "x86_64-linux"]

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -79,8 +79,8 @@ VITE_LLM_MODELS_PROD="ollama_llama3"
 
 [hook]
 on-activate = '''
-# If we export this here, it can be used later in 'profiles.common'
-export PYTHON_DIR="$FLOX_ENV_CACHE/python"
+  # If we export this here, it can be used later in 'profiles.common/bash'
+  export PYTHON_DIR="$FLOX_ENV_CACHE/python"
 
   test -d "${PYTHON_DIR}" \
     || uv venv "${PYTHON_DIR}" --allow-existing
@@ -89,6 +89,8 @@ export PYTHON_DIR="$FLOX_ENV_CACHE/python"
   uv pip install -r backend/requirements.txt
 
   yarn --cwd frontend install
+
+  ollama list | grep "^llama3" || ollama pull llama3
 '''
 
 

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -1,20 +1,20 @@
-# Flox manifest version managed by Flox CLI
+# manifest version managed by Flox CLI
 version = 1
 
-# List packages you wish to install in your environment inside
-# the `[install]` section.
 [install]
-# hello.pkg-path = "hello"
-# nodejs = { version = "^20.15.1", pkg-path = "nodejs" }
-
 # frontend deps
 nodejs.pkg-path = "nodejs"
 yarn.pkg-path = "yarn"
 
 # backend deps
-python3.pkg-path = "python3"
-gum.pkg-path = "gum"
+python.pkg-path = "python311"
+python.priority = 0
+
+google-crc32c.pkg-path = "python311Packages.google-crc32c"
+
+uv.pkg-path = "uv"
 cmake.pkg-path = "cmake"
+
 poppler_utils.pkg-path = "poppler_utils"
 tesseract.pkg-path = "tesseract"
 
@@ -28,12 +28,12 @@ glibc.systems = [ "x86_64-linux" , "aarch64-linux"]
 neo4j.pkg-path = "neo4j"
 ollama.pkg-path = "ollama"
 
-# Set environment variables in the `[vars]` section. These variables may not
-# reference one another, and are added to the environment without first
-# expanding them. They are available for use in the `[profile]` and `[hook]`
-# scripts.
+
 [vars]
-# Optional Backend
+UV_PYTHON_PREFERENCE = "only-system"
+UV_PYTHON_DOWNLOADS = "never"
+
+# Backend
 NEO4J_URI = "neo4j://localhost:7687"
 NEO4J_PASSWORD = "password"
 NEO4J_USERNAME = "neo4j"
@@ -61,7 +61,7 @@ GCS_FILE_CACHE = "False"
 # LLM_MODEL_CONFIG_fireworks_qwen_72b = ""
 LLM_MODEL_CONFIG_ollama_llama3 = "llama3,http://localhost:11434"
 
-# Optional Frontend
+# Frontend
 VITE_BACKEND_API_URL = "http://localhost:8000"
 VITE_REACT_APP_SOURCES="local,youtube,wiki,s3,web"
 VITE_GOOGLE_CLIENT_ID = ""
@@ -82,27 +82,30 @@ on-activate = '''
 # If we export this here, it can be used later in 'profiles.common'
 export PYTHON_DIR="$FLOX_ENV_CACHE/python"
 
-if [ ! -d "$PYTHON_DIR" ]; then
-  gum spin -s globe --title "Creating venv in $PYTHON_DIR..." -- python -m venv "$PYTHON_DIR"
-fi
-
-(
+  test -d "${PYTHON_DIR}" \
+    || uv venv "${PYTHON_DIR}" --allow-existing
   source "$PYTHON_DIR/bin/activate"
-  gum spin -s monkey --title "Installing/updating requirements.txt ..." -- pip install -r backend/requirements.txt
-)
+  
+  uv pip install -r backend/requirements.txt
 
-(
-  cd frontend
-  gum spin -s monkey --title "Installing/updating JS dependencies ..." -- yarn install
-)
+  yarn --cwd frontend install
 '''
 
 
 [profile]
-common = '''
-  # Activate the Python venv
-  source "$PYTHON_DIR/bin/activate"
+bash = '''
+source "$PYTHON_DIR/bin/activate"
 '''
+fish = '''
+source "$PYTHON_DIR/bin/activate.fish"
+'''
+tcsh = '''
+source "$PYTHON_DIR/bin/activate.csh"
+'''
+zsh = '''
+source "$PYTHON_DIR/bin/activate"
+'''
+
 
 [services]
 frontend.command = '''


### PR DESCRIPTION
uv has a faster, pip compatible experience + the interactive output is much nicer

this should resolve the hashing performance warning as well

- `yarn` and `uv` now interactively tell the user what they are doing
- activation now tells users how to check the status of the ollama model